### PR TITLE
Use Helm in the rest of steps to deploy the agent

### DIFF
--- a/k8s-deep-dive-2020/04-agent-everywhere.md
+++ b/k8s-deep-dive-2020/04-agent-everywhere.md
@@ -1,8 +1,16 @@
-The agent should run on all nodes in our cluster. To tolerate the master taint as well as any others that may be created, the agent should tolerate all taints. 
+The agent should run on all nodes in our cluster. To tolerate the master taint as well as any others that may be created, the agent should tolerate all taints.
 
-The workshop includes a patch to add the required toleration, you can review it opening this file: `assets/04-datadog-agent-everywhere/tolerate-all.patch.yaml`{{open}}.
+We have created a new Helm `values.yaml` file that includes this section:
 
-* Apply the patch: <br/>
-`kubectl patch daemonset datadog-agent --patch "$(cat assets/04-datadog-agent-everywhere/tolerate-all.patch.yaml)"`{{execute}}
+```
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+```
+
+You can view this new section opening this file: `assets/04-datadog-agent-everywhere/values.yaml`{{open}}. Navigate to line 975 to check the section.
+
+* Apply the new `values.yaml`: <br/>
+`helm upgrade datadogagent --set datadog.apiKey=$DD_API_KEY -f assets/04-datadog-agent-everywhere/values.yaml stable/datadog`{{execute}}
 
 * Verify that the agent is running on the master and worker nodes by executing `kubectl get pods -owide`{{execute}}

--- a/k8s-deep-dive-2020/08-logs.md
+++ b/k8s-deep-dive-2020/08-logs.md
@@ -1,10 +1,34 @@
-Our current Datadog agent configuration doesn't have logs collection enabled. We will enable log collection by passing two environment variables to the Agent: `DD_LOGS_ENABLED=true` and `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`. You can read more on our [official documentation](https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#log-collection).
+Our current Datadog agent configuration doesn't have logs collection enabled. We will enable log collection using this section of the Helm `values.yaml` file:
 
-We are going to patch our DaemonSet to add the required environment varibles. You can check the patch opening this file: `assets/08-datadog-logs/enable-logs.patch.yaml`{{open}}
+```
+  logs:
+    ## @param enabled - boolean - optional - default: false
+    ## Enables this to activate Datadog Agent log collection.
+    ## ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+    #
+    enabled: true
 
-Patch the Daemonset executing the following command `kubectl patch daemonset datadog-agent --patch "$(cat assets/08-datadog-logs/enable-logs.patch.yaml)"`{{execute}}
+    ## @param containerCollectAll - boolean - optional - default: false
+    ## Enable this to allow log collection for all containers.
+    ## ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+    #
+    containerCollectAll: true
+```
 
-* Check if your change has been rolled out:<br/>
-`kubectl get pods -lapp=datadog-agent`{{execute}}
+You can read more on our [official documentation](https://docs.datadoghq.com/agent/kubernetes/log/?tab=helm).
 
-**Even with the new manifest uploaded, pods are not updated. The default rollout strategy for the `DaemonSet` is `OnDelete` [which means according to the documentation](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/) a Pod must be deleted to be replaced. To automatically roll out changes, use the `RollingUpdate` strategy.**
+You can view this new section opening this file: `assets/08-datadog-logs/values.yaml`{{open}}. Navigate to line 208 to check the section.
+
+* Apply the new `values.yaml`: <br/>
+`helm upgrade datadogagent --set datadog.apiKey=$DD_API_KEY -f assets/08-datadog-logs/values.yaml stable/datadog`{{execute}}
+
+* Run the agent status command and check that logging is enabled: `kubectl exec $(kubectl get pod -l app=datadogagent -ojsonpath="{.items[0].metadata.name}") agent status`{{execute}}
+
+```
+==========
+Logs Agent
+==========
+
+    Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com on port 10516
+```
+

--- a/k8s-deep-dive-2020/10c-deploy-cluster-agent.md
+++ b/k8s-deep-dive-2020/10c-deploy-cluster-agent.md
@@ -1,18 +1,34 @@
-Now is time to deploy the Cluster Agent.
+Now is time to deploy the Cluster Agent. Again, this is very easy to do using the Datadog's Helm chart.
 
-* We are going to patch the Agent to enable the Cluster Agent's client and to configure the token for the communication to be secure.<br/>
-`kubectl apply -f assets/10c-deploy-cluster-agent/cluster-agent-manifests`{{execute}}
-
-* Patch the agent DaemonSet: <br/>
-`kubectl patch daemonset datadog-agent --patch "$(cat assets/10c-deploy-cluster-agent/enable-dca.patch.yaml)"`{{execute}}
-
-* Verify that the Cluster Agent is running: <br/>
-`kubectl get pod -lapp=datadog-cluster-agent`{{execute}}
-
-* Verify that the agent can properly communicate with it. Exec into an agent and use the `agent status` command.
+We will enable deploy the Cluster Agent using this section of the Helm `values.yaml` file:
 
 ```
-kubectl exec -ti datadog-agent-XXX agent status
+## @param clusterAgent - object - required
+## This is the Datadog Cluster Agent implementation that handles cluster-wide
+## metrics more cleanly, separates concerns for better rbac, and implements
+## the external metrics API so you can autoscale HPAs based on datadog metrics
+## ref: https://docs.datadoghq.com/agent/kubernetes/cluster/
+#
+clusterAgent:
+  ## @param enabled - boolean - required
+  ## Set this to true to enable Datadog Cluster Agent
+  #
+  enabled: true
+```
+
+You can read more on our [official documentation](https://docs.datadoghq.com/agent/kubernetes/log/?tab=helm).
+
+You can view this new section opening this file: `assets/10c-deploy-cluster-agent/values.yaml`{{open}}. Navigate to line 396 to check the section.
+
+* Apply the new `values.yaml`: <br/>
+`helm upgrade datadogagent --set datadog.apiKey=$DD_API_KEY -f assets/10c-deploy-cluster-agent/values.yaml stable/datadog`{{execute}}
+
+* Verify that the Cluster Agent is running: <br/>
+`kubectl get pod -lapp=datadogagent-cluster-agent`{{execute}}
+
+* Run the agent status command and check that the Node Agents can properly communicate with the Cluster Agent: `kubectl exec $(kubectl get pod -l app=datadogagent -ojsonpath="{.items[0].metadata.name}") agent status`{{execute}}
+
+```
 [...] 
 =====================
 Datadog Cluster Agent

--- a/k8s-deep-dive-ara-scratchpad/10c-deploy-cluster-agent.md
+++ b/k8s-deep-dive-ara-scratchpad/10c-deploy-cluster-agent.md
@@ -16,8 +16,6 @@ clusterAgent:
   enabled: true
 ```
 
-You can read more on our [official documentation](https://docs.datadoghq.com/agent/kubernetes/log/?tab=helm).
-
 You can view this new section opening this file: `assets/10c-deploy-cluster-agent/values.yaml`{{open}}. Navigate to line 396 to check the section.
 
 * Apply the new `values.yaml`: <br/>


### PR DESCRIPTION
Adding steps to use the Helm chart to deploy the agent in the controlplane node, enable logs and deploy the cluster agent