### PR TITLE
change master node name to controlplane

### DIFF
--- a/k8s-deep-dive-2020/03-agent-master.md
+++ b/k8s-deep-dive-2020/03-agent-master.md
@@ -1,3 +1,3 @@
-With the default configuration, the agent is only running on worker nodes. The master node has a taint applied preventing the `DaemonSet` from targeting it. To schedule a replica on a master node, a `toleration` matching the `taint` is required. You can read more about taints and tolerations in the [Kubernetes official documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+With the default configuration, the agent is only running on worker nodes. The controlplane node has a taint applied preventing the `DaemonSet` from targeting it. To schedule a replica on a controlplane node, a `toleration` matching the `taint` is required. You can read more about taints and tolerations in the [Kubernetes official documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
-Find the taints applied to the master node by executing `kubectl describe node master`{{execute}} and finding the *Taints* section.
+Find the taints applied to the controlplane node by executing `kubectl describe node controlplane`{{execute}} and finding the *Taints* section.

--- a/k8s-deep-dive-2020/04-agent-everywhere.md
+++ b/k8s-deep-dive-2020/04-agent-everywhere.md
@@ -1,4 +1,4 @@
-The agent should run on all nodes in our cluster. To tolerate the master taint as well as any others that may be created, the agent should tolerate all taints.
+The agent should run on all nodes in our cluster. To tolerate the control plane taint as well as any others that may be created, the agent should tolerate all taints.
 
 We have created a new Helm `values.yaml` file that includes this section:
 
@@ -13,4 +13,4 @@ You can view this new section opening this file: `assets/04-datadog-agent-everyw
 * Apply the new `values.yaml`: <br/>
 `helm upgrade datadogagent --set datadog.apiKey=$DD_API_KEY -f assets/04-datadog-agent-everywhere/values.yaml stable/datadog`{{execute}}
 
-* Verify that the agent is running on the master and worker nodes by executing `kubectl get pods -owide`{{execute}}
+* Verify that the agent is running on the control plane and worker nodes by executing `kubectl get pods -owide`{{execute}}

--- a/k8s-deep-dive-2020/11-control-plane.md
+++ b/k8s-deep-dive-2020/11-control-plane.md
@@ -1,19 +1,19 @@
 The Kubernetes control plane integrations provide metrics tailored to the performance of each component.
 
 The control plane has several components that run in the `kube-system` namespace:
-`kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,NODE:spec.nodeName`{{copy}}
+`kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,NODE:spec.nodeName`{{execute}}
 
 ```
-NAME                             NODE
+NAME                                   NODE
 [...]
-etcd-master                      master
-kube-apiserver-master            master
-kube-controller-manager-master   master
-kube-scheduler-master            master
+etcd-controlplane                      controlplane
+kube-apiserver-controlplane            controlplane
+kube-controller-manager-controlplane   controlplane
+kube-scheduler-controlplane            controlplane
 [...]
 ```
 
-In this environment, the control plane pods (apiserver, controller-manager, scheduler) are deployed as [static pods](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) on the master node. 
+In this environment, the control plane pods (apiserver, controller-manager, scheduler) are deployed as [static pods](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) on the controlplane node.
 
 <details>
 <summary>Additional Information</summary>

--- a/k8s-deep-dive-2020/14-audit-logs.md
+++ b/k8s-deep-dive-2020/14-audit-logs.md
@@ -8,7 +8,7 @@ request log.
 
 <details>
 <summary>Additional Information</summary>
-The apiserver is running on the master node as a [_static
+The apiserver is running on the controlplane node as a [_static
 pod_](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) so this
 application can be configured via a local file manifest located in:
 `/etc/kubernetes/manifests/kube-apiserver.yaml`. <br/> <br/>


### PR DESCRIPTION
Katacoda has changed the name of the control plane node from master to controlplane. This change reflects this