### PR TITLE
Autodiscovery now works with static pods

### DIFF
--- a/k8s-deep-dive-2020/03-agent-master.md
+++ b/k8s-deep-dive-2020/03-agent-master.md
@@ -1,3 +1,3 @@
-With the default configuration, the agent is only running on worker nodes. The master node has a taint applied preventing the `DaemonSet` from targeting it. To schedule a replica on a master node, a `toleration` matching the `taint` is required. You can read more about taints and tolerations in the [Kubernetes official documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+With the default configuration, the agent is only running on worker nodes. The controlplane node has a taint applied preventing the `DaemonSet` from targeting it. To schedule a replica on a controlplane node, a `toleration` matching the `taint` is required. You can read more about taints and tolerations in the [Kubernetes official documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
-Find the taints applied to the master node by executing `kubectl describe node master`{{execute}} and finding the *Taints* section.
+Find the taints applied to the controlplane node by executing `kubectl describe node controlplane`{{execute}} and finding the *Taints* section.

--- a/k8s-deep-dive-2020/04-agent-everywhere.md
+++ b/k8s-deep-dive-2020/04-agent-everywhere.md
@@ -1,4 +1,4 @@
-The agent should run on all nodes in our cluster. To tolerate the master taint as well as any others that may be created, the agent should tolerate all taints.
+The agent should run on all nodes in our cluster. To tolerate the control plane taint as well as any others that may be created, the agent should tolerate all taints.
 
 We have created a new Helm `values.yaml` file that includes this section:
 
@@ -13,4 +13,4 @@ You can view this new section opening this file: `assets/04-datadog-agent-everyw
 * Apply the new `values.yaml`: <br/>
 `helm upgrade datadogagent --set datadog.apiKey=$DD_API_KEY -f assets/04-datadog-agent-everywhere/values.yaml stable/datadog`{{execute}}
 
-* Verify that the agent is running on the master and worker nodes by executing `kubectl get pods -owide`{{execute}}
+* Verify that the agent is running on the control plane and worker nodes by executing `kubectl get pods -owide`{{execute}}

--- a/k8s-deep-dive-2020/11-control-plane.md
+++ b/k8s-deep-dive-2020/11-control-plane.md
@@ -1,40 +1,48 @@
 The Kubernetes control plane integrations provide metrics tailored to the performance of each component.
 
 The control plane has several components that run in the `kube-system` namespace:
-`kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,NODE:spec.nodeName`{{copy}}
+`kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,NODE:spec.nodeName`{{execute}}
 
 ```
-NAME                             NODE
+NAME                                   NODE
 [...]
-etcd-master                      master
-kube-apiserver-master            master
-kube-controller-manager-master   master
-kube-scheduler-master            master
+etcd-controlplane                      controlplane
+kube-apiserver-controlplane            controlplane
+kube-controller-manager-controlplane   controlplane
+kube-scheduler-controlplane            controlplane
 [...]
 ```
 
-In this environment, the control plane pods (apiserver, controller-manager, scheduler) are deployed as [static pods](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) on the master node. 
+In this environment, the control plane pods (apiserver, controller-manager, scheduler) are deployed as [static pods](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) on the controlplane node.
 
-<details>
-<summary>Additional Information</summary>
-Support for auto-detecting and discovering the static pods (it required some [contributions upstream](https://github.com/DataDog/datadog-agent/issues/2803#issuecomment-494073838)) is in progress. Until upstream accepts these contributions, we offer a workaround to schedule checks against static pods. A placeholder pod is created, on which we can add annotations used to drive Agent Checks configuration.
+* Verify that the checks are running for `etcd`, `kube_apiserver`, `kube_scheduler`, and `kube_controller_manager`: `k exec $(k get pod -l app=datadogagent --field-selector spec.nodeName=controlplane -ojsonpath="{.items[0].metadata.name}") agent status`{{execute}}
 
-The configuration in `assets/11-control-plane/static-pods-discovery.yaml` drives the static pod autodiscovery. See the ([official documetation](https://docs.datadoghq.com/agent/autodiscovery/integrations/?tab=kubernetespodannotations#configuration)).
-</details>
+The `etcd` check was automatically run thanks to [Datadog's Autodiscovery feature](https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes), but it seems that the default configuration didn't work. The reason our metrics call is failing is that we aren't making that secure connection. We need to change the check configuration to point to the right certificates. How do we do that if the check was automatically run with Autodiscovery? Datadog's Autodiscovery feature allows to change the check configuration adding annotations to the pod that is the target of the check, in our case, the `etcd-controlplane` pod. You can learn more about adding the right annotations to your pods in our [official documentation](https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes#configuration).
 
-* Deploy the control plane checks:
-`kubectl apply -f assets/11-control-plane/static-pods-discovery.yaml`{{copy}}
+But, where is the `etcd-controlplane` pod definition? The ETCD pod is defined as a [static pod in Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/#configuration-files). A folder in the file system can be watched by the Kubelet and start the pods that are described in that folder. In our environment this folder is `/etc/kubernetes/manifests`. Check the contents of that folder: `ls /etc/kubernetes/manifests`{{execute}}
 
-* Verify that the checks are running for `etcd`, `kube_apiserver`, `kube_scheduler`, and `kube_controller_manager`.
+Our pod definition is on the `etcd.yaml` file. We have created a new one that adds the following annotations to the pod:
 
-<details>
-<summary>Hint</summary>
-To verify a check is running, exec into the agent on the host and verify it's configuration. <br/> <br/>
+```
+  annotations:
+    ad.datadoghq.com/etcd.check_names: '["etcd"]'
+    ad.datadoghq.com/etcd.init_configs: '[{}]'
+    ad.datadoghq.com/etcd.instances: |
+      [
+        {
+          "prometheus_url": "https://%%host%%:2379/metrics",
+          "ssl_verify": "false",
+          "use_preview": "true",
+          "ssl_ca_cert": "/keys/ca.crt",
+          "ssl_cert": "/keys/peer.crt",
+          "ssl_private_key": "/keys/peer.key"
+        }
+      ]
+```
 
-`agent configcheck` in the agent pod prints the checks the agent has scheduled. <br/> <br/>
+* Copy the one with annotations back the file to the static pods folder: `cp assets/11-control-plane/etcd.yaml /etc/kubernetes/manifests/`{{execute}}. The Kubelet will pick the new configuration and will restart the `etcd-controlplane` pod with the new configuration applied.
 
-`agent status` in the agent pod prints information about the metrics and logs the agent has collected.
-</details>
+* Verify that the `etcd` check is now running correctly: `k exec $(k get pod -l app=datadogagent --field-selector spec.nodeName=controlplane -ojsonpath="{.items[0].metadata.name}") agent status`{{execute}}
 
 Each control plane integration comes with a default dashboard: [etcd](https://app.datadoghq.com/screen/integration/75/etcd), [kube-scheduler](https://app.datadoghq.com/screen/integration/30270/kubernetes-scheduler), [kube-controller-manager](https://app.datadoghq.com/screen/integration/30271/kubernetes-controller-manager), and the kube-apiserver.
 
@@ -43,13 +51,12 @@ As an example for how to create custom dashboards in Datadog, we are going to cr
 * Create an APP key in your [Datadog account](https://app.datadoghq.com/account/settings#api).
 ![APP Key](./assets/dashboard.png)
 
-* Run the following API call using the JSON description of the dashboard located in assets/11-control-plane/control_plane_json.json
-
+* Run the following API call using the JSON description of the dashboard located in `assets/11-control-plane/control_plane_json.json`{{open}}
 
 `export DD_APP_KEY=<YOUR_APP_KEY>`{{copy}}
 
 `curl -s -o /dev/null -X POST -H "Content-type: application/json" \
 -d @assets/11-control-plane/control_plane_json.json \
-"https://api.datadoghq.com/api/v1/dashboard?api_key=${DD_API_KEY}&application_key=${DD_APP_KEY}"`{{copy}}
+"https://api.datadoghq.com/api/v1/dashboard?api_key=${DD_API_KEY}&application_key=${DD_APP_KEY}"`{{execute}}
 
 Go check out your unified dashboard in the [Dashboard list](https://app.datadoghq.com/dashboard/lists?q=Kubernetes+Control+Plane)

--- a/k8s-deep-dive-2020/14-audit-logs.md
+++ b/k8s-deep-dive-2020/14-audit-logs.md
@@ -8,7 +8,7 @@ request log.
 
 <details>
 <summary>Additional Information</summary>
-The apiserver is running on the master node as a [_static
+The apiserver is running on the controlplane node as a [_static
 pod_](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) so this
 application can be configured via a local file manifest located in:
 `/etc/kubernetes/manifests/kube-apiserver.yaml`. <br/> <br/>


### PR DESCRIPTION
Since Autodiscovery works now with static pods, the workaround is no longer needed